### PR TITLE
Allow sorting by multiple columns. Improved fix for issue-33 - sorting breaks when filtering

### DIFF
--- a/src/main/java/org/vaadin/maddon/FilterableListContainer.java
+++ b/src/main/java/org/vaadin/maddon/FilterableListContainer.java
@@ -2,8 +2,6 @@ package org.vaadin.maddon;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -12,9 +10,6 @@ import com.vaadin.data.Container;
 import com.vaadin.data.Container.Filterable;
 import com.vaadin.data.Item;
 import com.vaadin.data.util.filter.UnsupportedFilterException;
-import org.apache.commons.beanutils.BeanComparator;
-import org.apache.commons.collections.comparators.NullComparator;
-import org.apache.commons.collections.comparators.ReverseComparator;
 
 /**
  * A filterable ({@link Container.Filterable}) version of {@link ListContainer}.
@@ -31,9 +26,6 @@ public class FilterableListContainer<T> extends ListContainer<T> implements
     private Set<Filter> filters = new HashSet<Filter>();
 
     private List<T> filteredItems = new ArrayList<T>();
-
-    private Object[] lastSortedPropertyId;
-    private boolean[] lastAscending;
 
     public FilterableListContainer(Class<T> type) {
         super(type);
@@ -68,10 +60,6 @@ public class FilterableListContainer<T> extends ListContainer<T> implements
 
     private void filterContainer() {
         applyFilters();
-        if (lastSortedPropertyId != null && lastAscending != null) {
-          sort(lastSortedPropertyId, lastAscending);
-        }
-
         super.fireItemSetChange();
     }
 
@@ -190,20 +178,11 @@ public class FilterableListContainer<T> extends ListContainer<T> implements
 
     @Override
     public void sort(Object[] propertyId, boolean[] ascending) {
-        lastSortedPropertyId = propertyId;
-        lastAscending = ascending;
+      super.sort(propertyId, ascending);
 
-        if (isFiltered()) {
-            Comparator c = new NullComparator();
-            if (!ascending[0]) {
-                c = new ReverseComparator(c);
-            }
-            BeanComparator<T> bc = new BeanComparator<T>(propertyId[0].
-                    toString(), c);
-            Collections.sort(filteredItems, bc);
-        } else {
-            super.sort(propertyId, ascending);
-        }
+      if (isFiltered()) {
+        filterContainer();
+      }
     }
 
 }

--- a/src/main/java/org/vaadin/maddon/ListContainer.java
+++ b/src/main/java/org/vaadin/maddon/ListContainer.java
@@ -15,14 +15,19 @@
  */
 package org.vaadin.maddon;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import com.vaadin.data.Container;
 import com.vaadin.data.Container.ItemSetChangeNotifier;
 import com.vaadin.data.Item;
 import com.vaadin.data.Property;
 import com.vaadin.data.util.AbstractContainer;
-
-import java.util.*;
-
 import org.apache.commons.beanutils.BeanComparator;
 import org.apache.commons.beanutils.DynaBean;
 import org.apache.commons.beanutils.DynaProperty;
@@ -259,12 +264,9 @@ public class ListContainer<T> extends AbstractContainer implements
 
     @Override
     public void sort(Object[] propertyId, boolean[] ascending) {
-        Comparator c = new NullComparator();
-        if (!ascending[0]) {
-            c = new ReverseComparator(c);
-        }
-        BeanComparator<T> bc = new BeanComparator<T>(propertyId[0].toString(), c);
-        Collections.sort(backingList, bc);
+      Comparator<T> comparator = new PropertyComparator(propertyId, ascending);
+
+      Collections.sort(backingList, comparator);
     }
 
     @Override
@@ -296,6 +298,47 @@ public class ListContainer<T> extends AbstractContainer implements
 
     public void removeListener(Container.ItemSetChangeListener listener) {
         super.removeListener(listener);
+    }
+
+    /**
+     *
+     * Override point. Allows user to use custom comparators based on properties.
+     * @param property
+     * @return Comparator that will compare two objects based on a property
+     */
+    protected Comparator<T> getUnderlyingComparator(Object property) {
+      return new NullComparator();
+    }
+
+    private class PropertyComparator implements Comparator<T> {
+
+      private final Object[] propertyId;
+      private final boolean[] ascending;
+
+      private PropertyComparator(Object[] propertyId, boolean[] ascending) {
+        this.propertyId = propertyId;
+        this.ascending = ascending;
+      }
+
+      @Override
+      public int compare(T o1, T o2) {
+        for (int i = 0; i < propertyId.length; i++) {
+          String currentProperty = propertyId[i].toString();
+          Comparator<T> currentComparator =
+                new BeanComparator<T>(currentProperty, getUnderlyingComparator(currentProperty));
+
+          if(!ascending[i]) {
+            currentComparator = new ReverseComparator(currentComparator);
+          }
+
+          int compare = currentComparator.compare(o1, o2);
+          if (compare != 0) {
+            return compare;
+          }
+        }
+
+        return 0;
+      }
     }
 
     public class DynaBeanItem<T> implements Item {

--- a/src/test/java/org/vaadin/maddon/FilterableListContainerTest.java
+++ b/src/test/java/org/vaadin/maddon/FilterableListContainerTest.java
@@ -27,6 +27,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryUsage;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 import java.util.logging.Logger;
@@ -34,8 +35,10 @@ import junit.framework.Assert;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 
 import org.junit.Test;
+import org.junit.matchers.JUnitMatchers;
 
 import static org.junit.Assert.*;
+import static org.junit.matchers.JUnitMatchers.hasItems;
 
 /**
  *
@@ -291,4 +294,26 @@ public class FilterableListContainerTest {
        }
    }
 
+  @Test
+  public void testMultiLevelSort() throws Exception {
+    FilterableListContainer<Person> lc = new FilterableListContainer<Person>(
+          new ArrayList<Person>(Arrays.asList(
+                new Person("2", "2", 3),
+                new Person("3", "2", 2),
+                new Person("1", "2", 2),
+                new Person("1", "1", 1),
+                new Person("1", "2", 4)
+          )));
+
+    lc.sort(new Object[]{"age", "firstName"}, new boolean[]{true, false});
+
+    Collection<Person> itemIds = lc.getItemIds();
+    assertThat(itemIds, hasItems(
+          new Person("1", "1", 1),
+          new Person("3", "2", 2),
+          new Person("1", "2", 2),
+          new Person("2", "2", 3),
+          new Person("1", "2", 4)
+    ));
+  }
 }

--- a/src/test/java/org/vaadin/maddon/Person.java
+++ b/src/test/java/org/vaadin/maddon/Person.java
@@ -57,6 +57,36 @@ public class Person {
     public void setAge(int age) {
         this.age = age;
     }
-    
-    
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final Person person = (Person)o;
+
+    if (age != person.age) {
+      return false;
+    }
+    if (firstName != null ? !firstName.equals(person.firstName) : person.firstName != null) {
+      return false;
+    }
+    if (lastName != null ? !lastName.equals(person.lastName) : person.lastName != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = firstName != null ? firstName.hashCode() : 0;
+    result = 31 * result + (lastName != null ? lastName.hashCode() : 0);
+    result = 31 * result + age;
+    return result;
+  }
 }


### PR DESCRIPTION
I noticed there was no support for sorting by multiple columns (a feature supported by the default BeanItemContainer). I also changed the fix for issue-33 to your recommendation. Additionally, I've added an override point (getUnderlyingComparator()) that allows users to define the way they want specific properties to be compared (e.g. I have an enum column that I want compared by its toString, rather than its enum order).